### PR TITLE
docs: add 1.2.0 changelog section for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-09
+
+### Security
+
+- Upgraded `github.com/opencontainers/runc` from v1.2.3 to v1.2.8, resolving CVE-2025-31133, CVE-2025-52565, CVE-2025-52881 (High severity) and CVE-2026-41579 (Moderate severity)
+
+### Fixed
+
+- Fixed a flaky timing assertion in `TestApplyInLexicalOrder` (`ExecutionTimeInMillis` could legitimately be 0 for sub-millisecond migrations)
+
+### Known Issues
+
+- `github.com/jackc/pgx/v4` (<= v4.18.3) and `github.com/jackc/pgproto3/v2` (<= v2.3.3) still have known vulnerabilities; these are the final releases in their major version lines and require a migration to pgx/v5 to resolve
+
 ## [1.1.0] - 2026-05-02
 
 ### Changed
@@ -75,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File-based and directory-based migration loading
 - Configurable table names and schemas
 
-[Unreleased]: https://github.com/adlio/pgxschema/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/adlio/pgxschema/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/adlio/pgxschema/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/adlio/pgxschema/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/adlio/pgxschema/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/adlio/pgxschema/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @adlio :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Adds the `[1.2.0]` release section to `CHANGELOG.md`. This entry was authored on the PR #10 branch but was not included in the merge (PR #10 merged at the commit prior to the changelog commit), so `main` currently lacks a `[1.2.0]` section.

This is required before tagging `v1.2.0`, because the release workflow (`.github/workflows/release.yml`) extracts release notes by matching the `## [1.2.0]` header in `CHANGELOG.md`. Without this section, the published release would have empty notes.

## Changes

- Add `[1.2.0] - 2026-07-09` section documenting:
  - Security: `opencontainers/runc` v1.2.3 -> v1.2.8 (CVE-2025-31133, CVE-2025-52565, CVE-2025-52881, CVE-2026-41579)
  - Fixed: flaky `TestApplyInLexicalOrder` timing assertion
  - Known Issues: remaining `pgx/v4` and `pgproto3/v2` vulnerabilities requiring pgx/v5 migration
- Update changelog comparison links (`[Unreleased]` -> `v1.2.0...HEAD`, add `[1.2.0]` link)

## Testing

Documentation-only change. The section header matches the release workflow's extraction pattern.